### PR TITLE
Add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest
 pytruth
 pytest-cov
 hypothesis[pandas]
+requests


### PR DESCRIPTION
It seems that `requests` is also needed to run the scripts, and it is missing in the `requirements.txt` file.